### PR TITLE
Fixing Broken Saving

### DIFF
--- a/XLMenuMod.Utilities/Gear/CustomBoardGearInfo.cs
+++ b/XLMenuMod.Utilities/Gear/CustomBoardGearInfo.cs
@@ -1,4 +1,5 @@
-﻿using SkaterXL.Data;
+﻿using Newtonsoft.Json;
+using SkaterXL.Data;
 using System.Linq;
 using XLMenuMod.Utilities.Gear.Interfaces;
 using XLMenuMod.Utilities.Interfaces;
@@ -7,6 +8,7 @@ namespace XLMenuMod.Utilities.Gear
 {
 	public class CustomBoardGearInfo : BoardGearInfo, ICustomGearInfo
     {
+	    [JsonIgnore]
         public ICustomInfo Info { get; set; }
 
         public CustomBoardGearInfo(string name, string type, bool isCustom, TextureChange[] textureChanges, string[] tags) : base(name, type, isCustom, textureChanges, tags)

--- a/XLMenuMod.Utilities/Gear/CustomCharacterBodyInfo.cs
+++ b/XLMenuMod.Utilities/Gear/CustomCharacterBodyInfo.cs
@@ -1,4 +1,5 @@
-﻿using SkaterXL.Data;
+﻿using Newtonsoft.Json;
+using SkaterXL.Data;
 using System.Collections.Generic;
 using System.Linq;
 using XLMenuMod.Utilities.Gear.Interfaces;
@@ -8,6 +9,7 @@ namespace XLMenuMod.Utilities.Gear
 {
 	public class CustomCharacterBodyInfo : CharacterBodyInfo, ICustomGearInfo
 	{
+		[JsonIgnore]
 		public ICustomInfo Info { get; set; }
 
 		public CustomCharacterBodyInfo(string name, string type, bool isCustom, List<MaterialChange> materialChanges, string[] tags) : base(name, type, isCustom, materialChanges, tags)

--- a/XLMenuMod.Utilities/Gear/CustomCharacterGearInfo.cs
+++ b/XLMenuMod.Utilities/Gear/CustomCharacterGearInfo.cs
@@ -1,4 +1,5 @@
-﻿using SkaterXL.Data;
+﻿using Newtonsoft.Json;
+using SkaterXL.Data;
 using System.Linq;
 using XLMenuMod.Utilities.Gear.Interfaces;
 using XLMenuMod.Utilities.Interfaces;
@@ -7,6 +8,7 @@ namespace XLMenuMod.Utilities.Gear
 {
 	public class CustomCharacterGearInfo : CharacterGearInfo, ICustomGearInfo
     {
+	    [JsonIgnore]
         public ICustomInfo Info { get; set; }
 
         public CustomCharacterGearInfo(string name, string type, bool isCustom, TextureChange[] textureChanges, string[] tags) : base(name, type, isCustom, textureChanges, tags)

--- a/XLMenuMod/Info.json
+++ b/XLMenuMod/Info.json
@@ -2,7 +2,7 @@
   "Id": "XLMenuMod",
   "DisplayName": "XL Menu Mod",
   "Author": "mcbtay",
-  "Version": "2.3.0",
+  "Version": "2.3.1",
   "ManagerVersion": "0.22.5.0",
   "Requirements": [],
   "AssemblyName": "XLMenuMod.dll",

--- a/XLMenuMod/XLMenuMod.csproj
+++ b/XLMenuMod/XLMenuMod.csproj
@@ -147,7 +147,7 @@ copy /Y "$(TargetDir)XLMenuMod.dll" "$(TargetDir)XLMenuMod\XLMenuMod.dll"
 copy /Y "$(TargetDir)XLMenuMod.Utilities.dll" "$(TargetDir)XLMenuMod\XLMenuMod.Utilities.dll"
 copy /Y "$(TargetDir)Info.json" "$(TargetDir)XLMenuMod\Info.json"
 
-powershell Compress-Archive -Path '$(TargetDir)XLMenuMod' -DestinationPath '$(TargetDir)XLMenuMod-2-3-0.zip' -Force
+powershell Compress-Archive -Path '$(TargetDir)XLMenuMod' -DestinationPath '$(TargetDir)XLMenuMod-2-3-1.zip' -Force
 )</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/XLMenuMod/repository.json
+++ b/XLMenuMod/repository.json
@@ -3,7 +3,7 @@
     {
       "Id": "XLMenuMod",
       "Version": "2.2.2",
-      "DownloadUrl": "https://github.com/MCBTay/XLMenuMod/releases/download/2.3.0/XLMenuMod-2-3-0.zip"
+      "DownloadUrl": "https://github.com/MCBTay/XLMenuMod/releases/download/2.3.1/XLMenuMod-2-3-1.zip"
     }
   ]
 }


### PR DESCRIPTION
Serialization of clothing objects slightly changed and without some `[JsonIgnore]` attributes, serialization would result in circular references.  This in turn caused people to not be able to save their gear.