### PR TITLE
Ignore Custom Skaters

### DIFF
--- a/XLMenuMod/Patches/Gear/GearDatabasePatch.cs
+++ b/XLMenuMod/Patches/Gear/GearDatabasePatch.cs
@@ -17,6 +17,7 @@ namespace XLMenuMod.Patches.Gear
 			static void Postfix(IndexPath index, GearInfo[][][] ___gearListSource, GearInfo[][][] ___customGearListSource, ref GearInfo[] __result)
 			{
 				// return out if it's not one of the tabs XLMenuMod is aware of.
+                if (index[0] >= Enum.GetNames(typeof(Skater)).Length) return;
 				if (index[1] < 0 || index[1] > (___gearListSource[index[0]].Length * 2) - 1) return;
 
 				List<ICustomInfo> sourceList = null;
@@ -66,6 +67,7 @@ namespace XLMenuMod.Patches.Gear
 				if (index.depth < 3) return;
 
 				// return out if it's not one of the tabs XLMenuMod is aware of.
+                if (index[0] >= Enum.GetNames(typeof(Skater)).Length) return;
 				if (index[1] < 0 || index[1] > (___gearListSource[index[0]].Length * 2) - 1) return;
 
 				List<ICustomInfo> sourceList = null;

--- a/XLMenuMod/Patches/Gear/GearSelectionControllerPatch.cs
+++ b/XLMenuMod/Patches/Gear/GearSelectionControllerPatch.cs
@@ -27,6 +27,7 @@ namespace XLMenuMod.Patches.Gear
 
 				var officialGear = Traverse.Create(GearDatabase.Instance).Field("gearListSource").GetValue<GearInfo[][][]>();
 				// return out if it's not one of the tabs XLMenuMod is aware of.
+                if (index[0] >= Enum.GetNames(typeof(Skater)).Length) return;
 				if (index[1] < 0 || index[1] > (officialGear[index[0]].Length * 2) - 1) return;
 
                 if (CustomGearManager.Instance.CurrentFolder == null) return;
@@ -72,6 +73,7 @@ namespace XLMenuMod.Patches.Gear
 
 				var officialGear = Traverse.Create(GearDatabase.Instance).Field("gearListSource").GetValue<GearInfo[][][]>();
 				// return out if it's not one of the tabs XLMenuMod is aware of.
+                if (index[0] >= Enum.GetNames(typeof(Skater)).Length) return;
 				if (index[1] < 0 || index[1] > (officialGear[index[0]].Length * 2) - 1) return;
 
 				bool isCustom = index[1] >= Enum.GetValues(typeof(GearCategory)).Length;
@@ -145,6 +147,7 @@ namespace XLMenuMod.Patches.Gear
 				if (index[0] < 0) return;
 
 				// return out if it's not one of the tabs XLMenuMod is aware of.
+                if (index[0] >= Enum.GetNames(typeof(Skater)).Length) return;
 				if (index[1] < 0 || index[1] > (officialGear[index[0]].Length * 2) - 1) return;
 
 				bool isCustom = index[0] < officialGear.Length && index[1] >= officialGear[index[0]].Length;
@@ -172,6 +175,7 @@ namespace XLMenuMod.Patches.Gear
 				if (index[0] < 0) return true;
 
 				// return out if it's not one of the tabs XLMenuMod is aware of.
+                if (index[0] >= Enum.GetNames(typeof(Skater)).Length) return true;
 				if (index[1] < 0 || index[1] > (officialGear[index[0]].Length * 2) - 1) return true;
 
 				var gear = GearDatabase.Instance.GetGearAtIndex(index);
@@ -260,6 +264,7 @@ namespace XLMenuMod.Patches.Gear
 				if (index[0] < 0) return;
 
 				// return out if it's not one of the tabs XLMenuMod is aware of.
+                if (index[0] >= Enum.GetNames(typeof(Skater)).Length) return;
 				if (index[1] < 0 || index[1] > (officialGear[index[0]].Length * 2) - 1) return;
 
 				if (index.depth >= 3)


### PR DESCRIPTION
XLGearModifier introduced some functionality to add custom skaters.  XLMenuMod was getting confused on how to filter some of the tabs.  Updating XLMenuMod to no longer filter or manipulate any of the custom skater menus.  That should be on XLGearModifier to handle.